### PR TITLE
style.css: less offensive text-shadow in .about b

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -159,7 +159,8 @@ header.site .slogan {
 }
 .about b {
   font-weight: 500;
-  text-shadow: 2px 1px 0 rgba(0, 0, 0, 0.15);
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.15);
+  letter-spacing: -0.04em;
 }
 
 h2 { 


### PR DESCRIPTION
2px right looks a little bit blurry in my opinion.
The use of letter-spacing has also the advantage to work in older browsers.
