### PR TITLE
Fix filter button style breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 * URL longener?
 * Fix empty downloads.type
 * filter.js:
-  * Fix button style breakage in Mozilla
   * Fix z-index (Android?)
 * New {feeds,downloads}.{lang,summary,type} in:
   * Downloads Feeds

--- a/static/style.css
+++ b/static/style.css
@@ -807,7 +807,6 @@ background-color: #efefeb; color: #312c2a;
 .filterbutton:after {
   content: "\25BE";
   border-left: 0.075em solid rgba(0,0,0,0.1);
-  float: right;
   font: 120%/1.6 zocial;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
Generated content with the :after pseudo element
is inline by default.

If the float attribute is needed somehow, we should try a :before and float it right.
